### PR TITLE
[umeng_analytics_plugin] Fix event failure => label can't null

### DIFF
--- a/lib/umeng_analytics_plugin.dart
+++ b/lib/umeng_analytics_plugin.dart
@@ -61,7 +61,7 @@ class UmengAnalyticsPlugin {
   }
 
   /// Send a general event for [eventId] with a [label]
-  static Future<bool> event(String eventId, {String label}) async {
+  static Future<bool> event(String eventId, {String label= 'label'}) async {
     Map<String, dynamic> map = {
       'eventId': eventId,
     };


### PR DESCRIPTION
主要是针对Android的自定义事件失效问题修改，label不能为null，否则记录失效